### PR TITLE
(#23)  First pass at /submits command.  Lots of formatting work to do.

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -4,6 +4,7 @@ import datetime
 from web.events import linkers
 from web.slashes.knobs import handle_knobs
 from web.slashes.jobads import handle_jobads
+from web.slashes.submits import handle_submits
 from web.slashes.classad_eval import handle_classad_eval
 
 
@@ -43,4 +44,5 @@ SLASH_COMMANDS = {
     "knobs": handle_knobs,
     "classad_eval": handle_classad_eval,
     "jobads": handle_jobads,
+    "submits": handle_submits,
 }

--- a/web/slashes/submits.py
+++ b/web/slashes/submits.py
@@ -1,0 +1,76 @@
+import bs4
+from flask import current_app, request
+
+from ..executor import executor
+from .. import http, slack, formatting, html
+
+import re
+import os
+
+def handle_submits():
+    channel = request.form.get("channel_id")
+    submits = html.unescape(request.form.get("text")).split(" ")
+    user = request.form.get("user_id")
+
+    executor.submit(submits_reply, channel, submits, user)
+
+    return (
+        f"Looking for submit file command{formatting.plural(attrs)} {', '.join(formatting.bold(a) for a in attrs)}",
+        200,
+    )
+
+
+SUBMITS_URL = "https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html"
+
+
+def submits_reply(channel, attrs, user):
+    response = http.cached_get_url(SUBMITS_URL)
+    soup = bs4.BeautifulSoup(response.text, "html.parser")
+
+    descriptions = {attr: get_submits_description(soup, attr) for submit in submits}
+
+    msg_lines = [
+        f"<@{user}> asked for information on submit file command{formatting.plural(attrs)} {', '.join(formatting.bold(a) for s in submits)}"
+    ]
+
+    # TODO: this is clunky, we should make a function for this kind of grouping
+    good = {k: v for k, v in descriptions.items() if v is not None}
+    bad = {k: v for k, v in descriptions.items() if v is None}
+
+    if bad:
+        p1 = "they were" if len(bad) > 1 else "it was"
+        p2 = "don't" if len(bad) > 1 else "it doesn't"
+        msg_lines.append(
+            f"I couldn't find information on {', '.join(formatting.bold(k) for k, v in bad.items())}. Perhaps {p1} misspelled, or {p2} exist?"
+        )
+    msg_lines.extend(v + "\n" for v in good.values())
+
+    msg = "\n".join(msg_lines)
+
+    slack.post_message(channel=channel, text=msg)
+
+
+def get_submits_description(soup, attr):
+    try:
+        start = soup.find("div", id="submit-description-file-commands")
+        dts = start.find_all_next("dt", string=re.compile(f"^{attr} ", re.I))
+
+        for dt in dts:
+            description = dt.find_next("dd")
+            for converter in [
+                formatting.inplace_convert_em_to_underscores,
+                formatting.inplace_convert_code_to_backticks,
+                formatting.inplace_convert_strong_to_stars,
+                lambda soup: formatting.inplace_convert_internal_links_to_links(
+                    soup, os.path.dirname(SUBMITS_URL), "std.std-ref"
+                ),
+            ]:
+                converter(description)
+
+            text_description = formatting.compress_whitespace(description.text)
+            return f"{formatting.bold(dt.text)}\n>{text_description}"
+        return None
+
+    except Exception as e:
+        current_app.logger.exception(f"Error while trying to find job attr {attr}: {e}")
+        return None


### PR DESCRIPTION
The _condor_submit_ man page has a lot of more-complicated formatting to preserve, at least in the subset I looked at, than the knobs and job ad attributes, so we may not want to deploy this right away (or at least, not tell anyone about it).

This branch also needs to implement testing for `/submits` like we have for `/knobs` and `/jobads`.