### PR TITLE
Set up pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+#      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: check-docstring-first
+      - id: debug-statements
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+      - id: check-case-conflict
+      - id: forbid-new-submodules
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black

--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ ad (if not empty) and the result(s) to the channel.
 `/submits COMMAND [COMMAND_COMMAND ...]`
 
 The bot will look up the submit command(s) and echo them to the channel.
+
+
+## Development
+
+Once you've cloned the repository, run `pip install -r requirements-dev.txt`
+to install the development packages.
+
+This repository uses `pre-commit`.
+After installing development dependencies, run `pre-commit install`.
+**Do not commit before installing `pre-commit`!**

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,15 +2,15 @@ coverage:
   range: 50..100
   round: down
   precision: 0
-  
+
   status:
-    
+
     project:
       default:
         target: auto
         threshold: 20
         only_pulls: true
-        
+
     patch:
       default:
         target: auto

--- a/database-management.md
+++ b/database-management.md
@@ -13,4 +13,3 @@ and `flask db upgrade` to apply the migration.
 **Commit migrations to git.**
 
 The production database is automatically upgraded in `release-tasks.sh`
-

--- a/migrations/versions/8a3dcea7f1b9_.py
+++ b/migrations/versions/8a3dcea7f1b9_.py
@@ -1,7 +1,7 @@
 """empty message
 
 Revision ID: 8a3dcea7f1b9
-Revises: 
+Revises:
 Create Date: 2020-05-17 22:44:05.698552
 
 """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
-pytest==5.4.2
-pytest-flask==1.0.0
-pytest-mock==3.1.0
-pytest-cov==2.8.1
+pytest
+pytest-flask
+pytest-mock
+pytest-cov
+pre-commit

--- a/rss/README.md
+++ b/rss/README.md
@@ -11,4 +11,3 @@ whose `id` is `lambda.py`.  To that item, add `last_update_seen`
 past which events will be considered new; and `rss_shared_secret`,
 the shared secret you added to the environment (as `RSS_SHARED_SECRET`)
 in Heroku.
-

--- a/tests/commands/test_jobads.py
+++ b/tests/commands/test_jobads.py
@@ -27,35 +27,35 @@ ATTRS_HTML = textwrap.dedent(
     <dt><code class="docutils literal notranslate"><span class="pre">AcctGroup</span></code></dt>
     <dd>The accounting group name, as set in the submit description file via
     the
-    <strong>accounting_group</strong> <span class="target" id="index-5"></span> 
+    <strong>accounting_group</strong> <span class="target" id="index-5"></span>
     command. This attribute is only present if an accounting group was
     requested by the submission. See the <a class="reference internal" href="../admin-manual/user-priorities-negotiation.html"><span class="doc">User Priorities and Negotiation</span></a> section
     for more information about accounting groups.
-    <span class="target" id="index-6"></span> 
+    <span class="target" id="index-6"></span>
     <span class="target" id="index-7"></span> </dd>
     <dt><code class="docutils literal notranslate"><span class="pre">AcctGroupUser</span></code></dt>
     <dd>The user name associated with the accounting group. This attribute
     is only present if an accounting group was requested by the
-    submission. <span class="target" id="index-8"></span> 
+    submission. <span class="target" id="index-8"></span>
     <span class="target" id="index-9"></span> </dd>
     <dt><code class="docutils literal notranslate"><span class="pre">AllRemoteHosts</span></code></dt>
     <dd>String containing a comma-separated list of all the remote machines
     running a parallel or mpi universe job.
-    <span class="target" id="index-10"></span> 
+    <span class="target" id="index-10"></span>
     <span class="target" id="index-11"></span> </dd>
     <dt><code class="docutils literal notranslate"><span class="pre">Args</span></code></dt>
     <dd>A string representing the command line arguments passed to the job,
     when those arguments are specified using the old syntax, as
     specified in
     the <a class="reference internal" href="../man-pages/condor_submit.html"><span class="doc">condor_submit</span></a> section.
-    <span class="target" id="index-12"></span> 
+    <span class="target" id="index-12"></span>
     <span class="target" id="index-13"></span> </dd>
     <dt><code class="docutils literal notranslate"><span class="pre">Arguments</span></code></dt>
     <dd>A string representing the command line arguments passed to the job,
     when those arguments are specified using the new syntax, as
     specified in
     the <a class="reference internal" href="../man-pages/condor_submit.html"><span class="doc">condor_submit</span></a> section.
-    <span class="target" id="index-14"></span> 
+    <span class="target" id="index-14"></span>
     <span class="target" id="index-15"></span> </dd>
     """
 ).strip()

--- a/tests/commands/test_submits.py
+++ b/tests/commands/test_submits.py
@@ -205,7 +205,7 @@ SUBMITS_HTML = textwrap.dedent(
     </pre></div>
     </div>
     <p class="last">If the environment is set with the
-    <strong>environment</strong> <span class="target" id="index-16"></span> 
+    <strong>environment</strong> <span class="target" id="index-16"></span>
     command and <strong>getenv</strong> <span class="target" id="index-17"></span>  is
     also set to true, values specified with <strong>environment</strong> override
     values in the submitter’s environment (regardless of the order of

--- a/web/rss.py
+++ b/web/rss.py
@@ -1,10 +1,9 @@
-from flask import request
-from flask import current_app
-
-from . import slack
-
 import bs4
+
+from flask import request, current_app
+
 from . import formatting
+from . import slack
 
 
 class RSSCommandHandler:

--- a/web/utils.py
+++ b/web/utils.py
@@ -23,8 +23,8 @@ class ForgetfulDict:
 
         self._last_cleanup = time.monotonic()
 
-        self._cache = dict()
-        self._memory = dict()
+        self._cache = {}
+        self._memory = {}
 
     def __getitem__(self, key):
         now = time.monotonic()


### PR DESCRIPTION
This PR sets up `pre-commit` checks. Instructions for installation are in the revised readme.

One check is currently commented out (in `.pre-commit-config.yaml`), `check-yaml`, because it complains about
```
could not determine a constructor for the tag '!Ref'
  in "rss/template.yaml", line 25, column 36
```
which I'm not sure how to fix, if it's even an error.